### PR TITLE
Add initial tests of helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node_modules/.bin/mocha ./test/**.js || true",
     "start": "node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jquery": "^3.1.1"
+    "jquery": "^3.1.1",
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
   },
   "dependencies": {
     "body-parser": "^1.17.1",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,3 +4,6 @@ const validateHTTP = (url) => {
   }
   return url;
 }
+
+
+module.exports = validateHTTP

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -1,0 +1,5 @@
+const expect = require('chai').expect;
+
+describe('app', () => {
+  
+});

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -1,0 +1,13 @@
+const expect = require('chai').expect;
+const validateHTTP = require('../src/helpers');
+
+describe('helpers', () => {
+
+  it('adds http:// to url if not present', () => {
+    expect(validateHTTP('www.google.com')).to.equal('http://www.google.com');
+  });
+
+  it('does not add http:// if it already exists', () => {
+    expect(validateHTTP('http://www.google.com')).to.equal('http://www.google.com');
+  })
+});


### PR DESCRIPTION
Initial testing set up to run `npm test` in the terminal. Currently only 2 tests included for the addHTTP helper function. 